### PR TITLE
Create 703_kth-largest-element-in-a-stream.md

### DIFF
--- a/703/703_kth-largest-element-in-a-stream.md
+++ b/703/703_kth-largest-element-in-a-stream.md
@@ -1,0 +1,19 @@
+```C++
+class KthLargest {
+    int k;
+    priority_queue<int, vector<int>, greater<int>> pq;
+public:
+    KthLargest(int k_, vector<int>& nums) :k(k_) {
+        for(int point : nums) {
+            pq.push(point);
+            if(pq.size() > k) pq.pop();
+        }
+    }
+    
+    int add(int val) {
+        pq.push(val);
+        if(pq.size() > k) pq.pop();
+        return pq.top();
+    }
+};
+```


### PR DESCRIPTION
https://leetcode.com/problems/kth-largest-element-in-a-stream/
初期化や要素が追加されるごとに，配列をsort()して大きい順で上からk番目を返せばよいと思ったが，初期化の処理が上手くいかず，解答を見てしまったので，結局minヒープを使った． initializer listで変数を初期化すると，デフォルト値が代入されなくて済む．