### PR TITLE
Create find-k-pairs-with-smallest-sums.md

### DIFF
--- a/373/find-k-pairs-with-smallest-sums.md
+++ b/373/find-k-pairs-with-smallest-sums.md
@@ -2,7 +2,7 @@
 class Solution {
 public:
     vector<vector<int>> kSmallestPairs(vector<int>& nums1, vector<int>& nums2, int k) {
-        using T = tuple<int, int, int>;
+        using T = tuple<int, int, int>;　// (sum, i, j): nums1[i] + nums2[j], index i, index j
         priority_queue<T, vector<T>, greater<T>> pq;
         int n = nums1.size(), m = nums2.size();
         for (int i = 0; i < n && i < k; ++i) pq.emplace(nums1[i] + nums2[0], i, 0);

--- a/373/find-k-pairs-with-smallest-sums.md
+++ b/373/find-k-pairs-with-smallest-sums.md
@@ -1,0 +1,19 @@
+```C++
+class Solution {
+public:
+    vector<vector<int>> kSmallestPairs(vector<int>& nums1, vector<int>& nums2, int k) {
+        using T = tuple<int, int, int>;
+        priority_queue<T, vector<T>, greater<T>> pq;
+        int n = nums1.size(), m = nums2.size();
+        for (int i = 0; i < n && i < k; ++i) pq.emplace(nums1[i] + nums2[0], i, 0);
+        vector<vector<int>> ans;
+        while (k--) {
+            auto [sum, i, j] = pq.top();
+            ans.push_back({nums1[i], nums2[j]});
+            pq.pop();
+            if(j + 1 < m) pq.emplace(nums1[i] + nums2[j+1], i, j+1);
+        }
+        return ans;    
+    }
+};
+```

--- a/373/find-k-pairs-with-smallest-sums.md
+++ b/373/find-k-pairs-with-smallest-sums.md
@@ -11,7 +11,7 @@ public:
             auto [sum, i, j] = pq.top();
             ans.push_back({nums1[i], nums2[j]});
             pq.pop();
-            if(j + 1 < m) pq.emplace(nums1[i] + nums2[j+1], i, j+1);
+            if(j + 1 < m) pq.emplace(nums1[i] + nums2[j + 1], i, j + 1);
         }
         return ans;    
     }


### PR DESCRIPTION
https://leetcode.com/problems/find-k-pairs-with-smallest-sums/description/

memory limeted exceed回避の工夫を必要とする問題．min heapで(sum, i , j)を管理．その際，全要素をまとめて格納すると最大10^5 * 10^5 = 10^10となりメモリ不足になる．j = 0の場合の要素だけすべて格納し，それから(sum, i,  j)をpopした後，(sum', i, j + 1)をpushする処理をk回繰り返せば，メモリ不足を回避できた．